### PR TITLE
Added neptune blog

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,6 +35,7 @@
         "http://mentat.za.net/blog/feeds/tag_python.atom.xml",
         "http://metarabbit.wordpress.com/tag/python/feed/atom",
         "http://mfitzp.io/feeds/python.tag.atom.xml",
+        "https://neptune.ml/feed",
         "http://neuralensemble.blogspot.com/feeds/posts/default",
         "http://nipy.github.io/blog/feeds/all.rss.xml",
         "http://nmayorov.wordpress.com/tag/gsoc/feed/atom",


### PR DESCRIPTION
I've added a link to the feed of our [blog for ml practitioners](https://neptune.ml/blog)