### PR TITLE
Add feed for jbencook.com

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,6 +25,7 @@
         "http://issamlaradji.blogspot.com/feeds/posts/default?alt=rss",
         "http://ivory.idyll.org/blog/feeds/all.atom.xml",
         "http://jakevdp.github.io/feeds/all.atom.xml",
+        "https://jbencook.com/feed.xml",
         "http://jmetzen.github.io/feeds/python.rss",
         "http://jpktd.blogspot.com/feeds/posts/default",
         "http://maheshakya.github.io/feed.xml",


### PR DESCRIPTION
Hello, I've added a link to the RSS feed for my [Python scientific computing blog](https://jbencook.com).