### PR TITLE
Add scikit-learn blog

### DIFF
--- a/config.json
+++ b/config.json
@@ -71,7 +71,7 @@
         "http://www.numfocus.org/feed",
         "http://www.randalolson.com/tag/python/feed/",
         "http://www.spyder-ide.org/blog/feed.xml",
-        "https://blog.scikit-learn.org/"
+        "https://blog.scikit-learn.org/",
         "http://xuewei4d.github.io/feed.xml",
         "https://pav.iki.fi/blog.xml",
         "https://www.anaconda.com/blog/feed/",

--- a/config.json
+++ b/config.json
@@ -71,6 +71,7 @@
         "http://www.numfocus.org/feed",
         "http://www.randalolson.com/tag/python/feed/",
         "http://www.spyder-ide.org/blog/feed.xml",
+        "https://blog.scikit-learn.org/"
         "http://xuewei4d.github.io/feed.xml",
         "https://pav.iki.fi/blog.xml",
         "https://www.anaconda.com/blog/feed/",


### PR DESCRIPTION
we just created the official blog for the scikit-learn machine learning library and we want to share it to the community.
https://blog.scikit-learn.org/